### PR TITLE
Let conditions be specified in options hash

### DIFF
--- a/lib/model_iterator.rb
+++ b/lib/model_iterator.rb
@@ -105,8 +105,9 @@ class ModelIterator
     @joins = @options[:joins]
     @clause =  "#{@id_clause} #{op} ?"
     if @options[:conditions]
-      @clause += " AND (#{@options[:conditions].first})"
-      @clause_args = @options[:conditions][1..-1]
+      conditions = Array(@options[:conditions])
+      @clause += " AND (#{conditions.first})"
+      @clause_args = conditions[1..-1]
     elsif !args.empty?
       @clause += " AND (#{args.shift})"
       @clause_args = args

--- a/test/init_test.rb
+++ b/test/init_test.rb
@@ -136,3 +136,29 @@ class InitializationTestWithCustomWhereClauseInOptionsOverridingArguments < Mode
     assert_equal 10, @iter.limit
   end
 end
+
+class InitializationTestWithCustomWhereClauseInOptionsAsSql < ModelIterator::TestCase
+  def setup
+    @iter = ModelIterator.new Model,
+      :redis => RedisClient.new, :start_id => 5, :limit => 10,
+      :conditions => 'public = true'
+  end
+
+  def test_sets_klass
+    assert_equal Model, @iter.klass
+  end
+
+  def test_sets_current_id
+    assert_equal 5, @iter.current_id
+  end
+
+  def test_sets_conditions
+    assert_equal ['models.id > ? AND (public = true)', @iter.current_id], @iter.conditions
+  end
+
+  def test_sets_limit
+    assert_equal 10, @iter.limit
+  end
+end
+
+

--- a/test/iterate_test.rb
+++ b/test/iterate_test.rb
@@ -39,6 +39,18 @@ class IterateTest < ModelIterator::TestCase
     assert_equal %w(b c), names
   end
 
+  def test_loops_through_filtered_records_from_options_as_plain_sql
+    names = []
+    iter = ModelIterator.new Model,
+      :redis => RedisClient.new, :limit => 1,
+      :conditions => "name != 'a'"
+    iter.each do |m|
+      names << m.name
+    end
+
+    assert_equal %w(b c), names
+  end
+
   def test_loops_through_records_in_reverse
     names = []
     iter = ModelIterator.new Model, :redis => RedisClient.new, :limit => 1,


### PR DESCRIPTION
This lets you choose to call it as

``` ruby
ModelIterator.new(Model, 'public = ?', true, :limit => 10)
```

or

``` ruby
ModelIterator.new(Model, :limit => 10, :conditions => ['public = ?', true])
```

`:conditions` can be specified as an Array or String, and it will take precedence over what's given in the arguments.
