### PR TITLE
Update for ActiveRecord 4 API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :dev do
-  gem 'rake'
   gem 'activerecord'
   gem 'sqlite3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :dev do
-  gem 'activerecord'
   gem 'sqlite3'
 end
 

--- a/lib/model_iterator.rb
+++ b/lib/model_iterator.rb
@@ -204,7 +204,11 @@ class ModelIterator
   # Returns an Array of ActiveRecord::Base instances if any results are
   # returned, or nil.
   def records
-    arr = @klass.all(find_options)
+    options = find_options
+    query = @klass.where(options[:conditions]).limit(options[:limit]).order(options[:order])
+    query.select(options[:select]) if options[:select]
+    query.joins(options[:joins]) if options[:joins]
+    arr = query.to_a
     arr.empty? ? nil : arr
   end
 

--- a/lib/model_iterator.rb
+++ b/lib/model_iterator.rb
@@ -75,7 +75,6 @@ class ModelIterator
   #                        the ID field.  Default: "table_name.id"
   #           :start_id  - Fixnum to start iterating from.  Default: 1
   #           :prefix    - Custom String prefix for redis keys.
-  #           :select    - Optional String of the columns to retrieve.
   #           :joins     - Optional Symbol or Hash :joins option for 
   #                        ActiveRecord::Base.find.
   #           :max       - Optional Fixnum of the maximum number of iterations.
@@ -206,7 +205,6 @@ class ModelIterator
   def records
     options = find_options
     query = @klass.where(options[:conditions]).limit(options[:limit]).order(options[:order])
-    query.select(options[:select]) if options[:select]
     query.joins(options[:joins]) if options[:joins]
     arr = query.to_a
     arr.empty? ? nil : arr
@@ -217,9 +215,6 @@ class ModelIterator
   # Returns a Hash.
   def find_options
     opt = {:conditions => conditions, :limit => @limit, :order => "#{@id_clause} #{@order}"}
-    if columns = @options[:select]
-      opt[:select] = columns
-    end
     opt[:joins] = @joins if @joins
     opt
   end

--- a/lib/model_iterator.rb
+++ b/lib/model_iterator.rb
@@ -75,6 +75,7 @@ class ModelIterator
   #                        the ID field.  Default: "table_name.id"
   #           :start_id  - Fixnum to start iterating from.  Default: 1
   #           :prefix    - Custom String prefix for redis keys.
+  #           :select    - Optional String of the columns to retrieve.
   #           :joins     - Optional Symbol or Hash :joins option for 
   #                        ActiveRecord::Base.find.
   #           :max       - Optional Fixnum of the maximum number of iterations.
@@ -205,7 +206,8 @@ class ModelIterator
   def records
     options = find_options
     query = @klass.where(options[:conditions]).limit(options[:limit]).order(options[:order])
-    query.joins(options[:joins]) if options[:joins]
+    query = query.select(options[:select]) if options[:select]
+    query = query.joins(options[:joins]) if options[:joins]
     arr = query.to_a
     arr.empty? ? nil : arr
   end
@@ -215,6 +217,9 @@ class ModelIterator
   # Returns a Hash.
   def find_options
     opt = {:conditions => conditions, :limit => @limit, :order => "#{@id_clause} #{@order}"}
+    if columns = @options[:select]
+      opt[:select] = columns
+    end
     opt[:joins] = @joins if @joins
     opt
   end

--- a/model_iterator.gemspec
+++ b/model_iterator.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   ## require 'NAME.rb' or'/lib/NAME/file.rb' can be as require 'NAME/file.rb'
   s.require_paths = %w[lib]
 
+  s.add_dependency 'activerecord', '>=4.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'test-unit'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -29,8 +29,6 @@ class ModelIterator::TestCase < Test::Unit::TestCase
     end
   end
 
-  puts AssociatedModel.table_name
-
   class RedisClient
     def initialize(hash = nil)
       @hash = hash || {}

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,17 +3,33 @@ require 'test/unit'
 require 'active_record'
 require File.expand_path("../../lib/model_iterator", __FILE__)
 
+ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => ':memory:'
 class ModelIterator::TestCase < Test::Unit::TestCase
   class Model < ActiveRecord::Base
-    establish_connection :adapter => 'sqlite3', :database => ':memory:'
     connection.create_table table_name do |c|
       c.column :name, :string
     end
+
+    has_one :associated_model
 
     %w(a b c).each do |s|
       create!(:name => s)
     end
   end
+
+  class AssociatedModel < ActiveRecord::Base
+    connection.create_table table_name do |c|
+      c.integer :model_id
+    end
+
+    belongs_to :model
+
+    Model.all.each do |m|
+      create!(:model => m)
+    end
+  end
+
+  puts AssociatedModel.table_name
 
   class RedisClient
     def initialize(hash = nil)

--- a/test/iterate_test.rb
+++ b/test/iterate_test.rb
@@ -142,6 +142,14 @@ class IterateTest < ModelIterator::TestCase
     end
   end
 
+  def test_joins_can_be_used
+    redis = RedisClient.new
+    iter = ModelIterator.new Model, :redis => redis, :limit => 1, :joins => :associated_model
+    iter.each do |m|
+      assert_not_nil m.associated_model
+    end
+  end
+
   class ExpectedError < StandardError; end
 end
 

--- a/test/iterate_test.rb
+++ b/test/iterate_test.rb
@@ -133,6 +133,15 @@ class IterateTest < ModelIterator::TestCase
     assert_equal %w(a b c), names
   end
 
+  def test_select_option_honored
+    names = []
+    redis = RedisClient.new
+    iter = ModelIterator.new Model, :redis => redis, :limit => 1, :select => :id
+    iter.each do |m|
+      assert_false m.attributes.has_key?(:name)
+    end
+  end
+
   class ExpectedError < StandardError; end
 end
 


### PR DESCRIPTION
This removes the use of ActiveRecord 3.x `all` with options and uses the specific query building methods followed by `ActiveRecord::Relation.to_a` instead.

As far as I can tell, the tests do not test use fo a select or joins option so that stuff could be wrong.

- [x] Restrict dependencies to ActiveRecord `>= 4.0`?
- [ ] Consider whether there are refactoring possibilities to avoid wrapping up options into a hash only to unwrap them again buthonestlyitssundayandIimnotsuperfussed
- [x] Add tests for `:select` and `:joins` options?

cc #4 
